### PR TITLE
Add Remote Mailbox properties/alias/GAL/routing-address management

### DIFF
--- a/Start-ExchangeRecipientAdminCenter.ps1
+++ b/Start-ExchangeRecipientAdminCenter.ps1
@@ -139,7 +139,119 @@ try {
 				break
 			}
 
-			"GET /distributiongroups" { 
+			"GET /editremotemailbox" {
+				# View / edit a single Remote Mailbox's attributes
+
+				$Table = @{}
+				if ($REQUEST.Url.Query) {
+					foreach ($Item in [URI]::UnescapeDataString(($REQUEST.Url.Query.Replace("?", ""))).Split("&")) {
+						$Table.Add($Item.Split("=")[0], $Item.Split("=")[1])
+					}
+				}
+
+				$Identity = $Table['id']
+
+				# Apply a requested change, if any, before re-reading the mailbox
+				if ($Table.ContainsKey('action')) {
+					try {
+						switch ($Table['action']) {
+							"addalias" {
+								$NewAlias = "$($Table['alias_local'])@$($Table['alias_accepteddomain'])"
+								Set-RemoteMailbox -Identity $Identity -EmailAddresses @{Add = $NewAlias }
+								$HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Added alias $NewAlias")
+								break
+							}
+							"removealias" {
+								Set-RemoteMailbox -Identity $Identity -EmailAddresses @{Remove = $Table['alias'] }
+								$HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Removed alias $($Table['alias'])")
+								break
+							}
+							"togglehidden" {
+								$NewHidden = $Table['hidden'] -eq 'true'
+								Set-RemoteMailbox -Identity $Identity -HiddenFromAddressListsEnabled $NewHidden
+								$HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Set 'Hidden from address lists' to $NewHidden")
+								break
+							}
+							"setrra" {
+								Set-RemoteMailbox -Identity $Identity -RemoteRoutingAddress $Table['newrra']
+								$HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Remote routing address updated to $($Table['newrra'])")
+								break
+							}
+						}
+					}
+					catch {
+						$HTML_RESULT = $HTML_WARN.Replace("{result}", $Error -join "<br />")
+					}
+				}
+
+				# Look up the mailbox to display
+				$Mailbox = Get-RemoteMailbox -Identity $Identity -ErrorAction SilentlyContinue
+
+				if (-not $Mailbox) {
+					$RESPONSE.StatusCode = 404
+					$HTMLRESPONSE = "<!doctype html><html><body>Remote mailbox '$($Identity)' not found</body></html>"
+					break
+				}
+
+				# Prepare accepted domain list, used for the "add alias" domain picker
+				$HTMLROWS_AD = ""
+				foreach ($Item in (Get-AcceptedDomain)) {
+					$HTMLROWS_AD += "`n<option value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+				}
+
+				# Prepare proxy address (EmailAddresses) rows, each with a remove button
+				$HTMLROWS_PROXY = ""
+				foreach ($Addr in $Mailbox.EmailAddresses) {
+					$AddrString = $Addr.ToString()
+					$IsPrimary = $AddrString.StartsWith("SMTP:")
+					if ($IsPrimary) {
+						$Badge = "<span class=`"badge text-bg-primary`">Primary</span>"
+						$RemoveBtn = ""
+					}
+					else {
+						$Badge = "<span class=`"badge text-bg-secondary`">Alias</span>"
+						$EncodedId = [URI]::EscapeDataString($Identity)
+						$EncodedAddr = [URI]::EscapeDataString($AddrString)
+						$RemoveBtn = "<a class=`"btn btn-sm btn-outline-danger`" href=`"/editremotemailbox?id=$($EncodedId)&action=removealias&alias=$($EncodedAddr)`" onclick=`"return confirm('Remove $($AddrString)?')`">Remove</a>"
+					}
+					$HTMLROWS_PROXY += "
+					<tr>
+					<td>$($AddrString)</td>
+					<td>$($Badge)</td>
+					<td>$($RemoveBtn)</td>
+					</tr>";
+				}
+
+				if ($Mailbox.HiddenFromAddressListsEnabled) {
+					$HiddenBadgeClass = "text-bg-warning"
+					$HiddenStatusText = "Hidden"
+					$HiddenToggleValue = "false"
+					$HiddenToggleLabel = "Unhide from GAL"
+				}
+				else {
+					$HiddenBadgeClass = "text-bg-success"
+					$HiddenStatusText = "Visible"
+					$HiddenToggleValue = "true"
+					$HiddenToggleLabel = "Hide from GAL"
+				}
+
+				# Create response and replace template placeholders
+				$HTMLRESPONSE = Get-Content -Path "$($BASEDIR)\editremotemailbox.html"
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{display_name}", $Mailbox.Name)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{primarysmtpaddress}", $Mailbox.PrimarySmtpAddress)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{remoteroutingaddress}", $Mailbox.RemoteRoutingAddress)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{id}", [URI]::EscapeDataString($Identity))
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_badge_class}", $HiddenBadgeClass)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_status_text}", $HiddenStatusText)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_toggle_value}", $HiddenToggleValue)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_toggle_label}", $HiddenToggleLabel)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_proxy} -->", $HTMLROWS_PROXY)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_ad} -->", $HTMLROWS_AD)
+				$HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {result} -->", $HTML_RESULT)
+				break
+			}
+
+			"GET /distributiongroups" {
 				# Distribution Groups Section
 
 				# Prepare Distibution Group lists split into tabs

--- a/Start-ExchangeRecipientAdminCenter.ps1
+++ b/Start-ExchangeRecipientAdminCenter.ps1
@@ -151,6 +151,7 @@ try {
 				}
 
 				$Identity = $Table['id']
+				$MailboxDisabled = $false
 
 				# Apply a requested change, if any, before re-reading the mailbox
 				if ($Table.ContainsKey('action')) {
@@ -178,11 +179,73 @@ try {
 								$HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Remote routing address updated to $($Table['newrra'])")
 								break
 							}
+							"disable" {
+								# Require the confirmation text to match the mailbox's actual
+								# PrimarySmtpAddress - checked server-side too, not just via the
+								# UI's type-to-confirm JS, since that's trivially bypassed.
+								$MailboxToDisable = Get-RemoteMailbox -Identity $Identity -ErrorAction SilentlyContinue
+								if (-not $MailboxToDisable) {
+									$HTML_RESULT = $HTML_WARN.Replace("{result}", "Remote mailbox '$($Identity)' not found")
+								}
+								elseif ($Table['confirmAddress'] -ne $MailboxToDisable.PrimarySmtpAddress) {
+									$HTML_RESULT = $HTML_WARN.Replace("{result}", "Confirmation text didn't match $($MailboxToDisable.PrimarySmtpAddress) - no changes were made")
+								}
+								else {
+									Disable-RemoteMailbox -Identity $Identity -Confirm:$false
+									$HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Remote Mailbox for $($MailboxToDisable.PrimarySmtpAddress) has been disabled")
+									$MailboxDisabled = $true
+								}
+								break
+							}
 						}
 					}
 					catch {
 						$HTML_RESULT = $HTML_WARN.Replace("{result}", $Error -join "<br />")
 					}
+				}
+
+				# A disabled mailbox no longer exists to render an edit page for -
+				# send the user back to the Remote Mailboxes list instead.
+				if ($MailboxDisabled) {
+					$HTMLROWS_USERS = ""
+					foreach ($Item in (Get-User -Filter "RecipientType -eq 'User' -and RecipientTypeDetails -ne 'DisabledUser'" | Where { $_.UserPrincipalName })) {
+						$HTMLROWS_USERS += "`n<option value=`"$($Item.UserPrincipalName)`">$($Item.UserPrincipalName)</option>"
+					}
+
+					$HTMLROWS_AD = ""
+					foreach ($Item in (Get-AcceptedDomain)) {
+						if ($Item.Default) {
+							$HTMLROWS_AD += "`n<option selected value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+						}
+						else {
+							$HTMLROWS_AD += "`n<option value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+						}
+					}
+
+					$HTMLROWS_RRA = ""
+					foreach ($Item in (Get-AcceptedDomain)) {
+						if ($Item.DomainName -like "*.mail.onmicrosoft.com") {
+							$HTMLROWS_RRA += "`n<option selected value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+						}
+						else {
+							$HTMLROWS_RRA += "`n<option value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+						}
+					}
+
+					$HTMLROWS_MBX = ""
+					foreach ($Item in (Get-RemoteMailbox | Select DisplayName, PrimarySMTPAddress, RecipientTypeDetails, WhenChanged)) {
+						$HTMLROWS_MBX += "
+						<tr>
+						<th scope=`"row`">
+						<a href=`"/editremotemailbox?id=$($Item.PrimarySMTPAddress)`">$($Item.DisplayName)</a></th>
+						<td>$($Item.PrimarySMTPAddress)</td>
+						<td>$($Item.RecipientTypeDetails)</td>
+						<td>$($Item.WhenChanged)</td>
+						</tr>";
+					}
+
+					$HTMLRESPONSE = (Get-Content -Path "$($BASEDIR)\remotemailboxes.html").Replace("<!-- {row_mbx} -->", $HTMLROWS_MBX).Replace("<!-- {row_ad} -->", $HTMLROWS_AD).Replace("<!-- {row_user} -->", $HTMLROWS_USERS).Replace("<!-- {row_rra} -->", $HTMLROWS_RRA).Replace("<!-- {result} -->", $HTML_RESULT)
+					break
 				}
 
 				# Look up the mailbox to display

--- a/Start-ExchangeRecipientAdminCenter.ps1
+++ b/Start-ExchangeRecipientAdminCenter.ps1
@@ -52,6 +52,7 @@ try {
 	"$(Get-Date -Format s) Powershell webserver started."
 	$WEBLOG = "$(Get-Date -Format s) Powershell webserver started.`n"
 	while ($LISTENER.IsListening) {
+	  try {
 		# analyze incoming request
 		$CONTEXT = $LISTENER.GetContext()
 		$REQUEST = $CONTEXT.Request
@@ -446,6 +447,15 @@ try {
 			"$(Get-Date -Format s) Stopping powershell webserver..."
 			break;
 		}
+	  }
+	  catch {
+		# A single request failing (e.g. client closed the connection before the
+		# response finished writing - "network name is no longer available") should
+		# not take down the whole webserver. Log it and keep listening.
+		"$(Get-Date -Format s) Request error: $($_.Exception.Message)"
+		$WEBLOG += "$(Get-Date -Format s) Request error: $($_.Exception.Message)`n"
+		try { $RESPONSE.Close() } catch { }
+	  }
 	}
 }
 finally {

--- a/web/editremotemailbox.html
+++ b/web/editremotemailbox.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Based on Bootstrap dashboard">
+    <title>Exchange Recipient Admin Center - Remote Mailbox</title>
+    <link href="node_modules/bootstrap/dist/css/bootstrap.min.css"
+      rel="stylesheet">
+    <link href="node_modules/@primer/octicons/build/build.css" rel="stylesheet">
+    <script src="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="node_modules/feather-icons/dist/feather.min.js"></script>
+    <link href="dashboard.css" rel="stylesheet">
+    <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico">
+  </head>
+  <body>
+
+    <header class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0
+      shadow">
+      <a class="navbar-brand col-md-3 col-lg-2 me-0 px-3" href="#">Exchange
+        Recipient Admin Center</a>
+      <button class="navbar-toggler position-absolute d-md-none collapsed"
+        type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu"
+        aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle
+        navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="navbar-nav">
+        <div class="nav-item text-nowrap">
+          <a class="nav-link px-3" href="/exit">Exit</a>
+        </div>
+      </div>
+    </header>
+
+    <div class="container-fluid">
+      <div class="row">
+        <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light
+          sidebar collapse">
+          <div class="position-sticky pt-3">
+            <ul class="nav flex-column">
+              <li class="nav-item">
+                <a class="nav-link" aria-current="page" href="/">
+                  <span data-feather="home"></span>
+                  Dashboard
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link active" href="/remotemailboxes">
+                  <span data-feather="user"></span>
+                  Remote Mailboxes
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/distributiongroups">
+                  <span data-feather="users"></span>
+
+                  Distribution Groups</a>
+              </li>
+
+              <li class="nav-item">
+                <a class="nav-link" href="/contacts">
+                  <span data-feather="mail"></span>
+                  Contacts
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/emailaddresspolicies">
+                  <span data-feather="list"></span>
+                  Email Address Policies
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/accepteddomains">
+                  <span data-feather="layers"></span>
+                  Accepted Domains
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="https://admin.exchange.microsoft.com/"
+                  target="_blank">
+                  <span data-feather="external-link"></span>
+                  Exchange Admin Center
+                </a>
+              </li>
+            </ul>
+
+
+          </div>
+        </nav>
+
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+          <div class="d-flex justify-content-between flex-wrap flex-md-nowrap
+            align-items-center pt-3 pb-2 mb-3 border-bottom">
+            <h2 class="h2">{display_name}</h2>
+            <a class="btn btn-outline-secondary btn-sm" href="/remotemailboxes">Back to Remote Mailboxes</a>
+          </div>
+
+          <!-- {result} -->
+
+          <div class="card mb-4">
+            <div class="card-header">Properties</div>
+            <div class="card-body">
+              <dl class="row mb-0">
+                <dt class="col-sm-3">Name</dt>
+                <dd class="col-sm-9">{display_name}</dd>
+
+                <dt class="col-sm-3">Primary SMTP Address</dt>
+                <dd class="col-sm-9">{primarysmtpaddress}</dd>
+
+                <dt class="col-sm-3">Hidden from Address Lists</dt>
+                <dd class="col-sm-9">
+                  <span class="badge {hidden_badge_class}">{hidden_status_text}</span>
+                  <form method="get" action="/editremotemailbox" class="d-inline ms-2">
+                    <input type="hidden" name="id" value="{id}">
+                    <input type="hidden" name="action" value="togglehidden">
+                    <input type="hidden" name="hidden" value="{hidden_toggle_value}">
+                    <button type="submit" class="btn btn-outline-secondary btn-sm">{hidden_toggle_label}</button>
+                  </form>
+                </dd>
+              </dl>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">Remote Routing Address</div>
+            <div class="card-body">
+              <p class="text-muted">The cloud mailbox this Remote Mailbox is
+                routed to (RemoteRoutingAddress).</p>
+              <form method="get" action="/editremotemailbox" class="row g-2
+                align-items-center">
+                <input type="hidden" name="id" value="{id}">
+                <input type="hidden" name="action" value="setrra">
+                <div class="col-auto" style="min-width: 22rem;">
+                  <input type="text" name="newrra" class="form-control"
+                    value="{remoteroutingaddress}">
+                </div>
+                <div class="col-auto">
+                  <button type="submit" class="btn btn-primary btn-sm">Update
+                    Remote Routing Address</button>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between
+              align-items-center">
+              <span>Email Addresses (Proxy Addresses)</span>
+              <button type="button" class="btn btn-primary btn-sm"
+                data-bs-toggle="modal" data-bs-target="#addAlias">
+                Add alias
+              </button>
+            </div>
+            <div class="card-body">
+              <table class="table table-striped table-hover">
+                <thead>
+                  <tr>
+                    <th scope="col">Address</th>
+                    <th scope="col">Type</th>
+                    <th scope="col"></th>
+                  </tr>
+                </thead>
+                <tbody class="table-group-divider">
+                  <!-- {row_proxy} -->
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="modal fade" id="addAlias" tabindex="-1"
+            aria-labelledby="addAlias" aria-hidden="true">
+            <div class="modal-dialog modal-xl">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title">Add email alias</h5>
+                  <button type="button" class="btn-close"
+                    data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                  <form method="get" action="/editremotemailbox">
+                    <input type="hidden" name="id" value="{id}">
+                    <input type="hidden" name="action" value="addalias">
+                    <p>Add a secondary SMTP address (alias) to this mailbox.</p>
+                    <div class="row mb-3">
+                      <label for="alias_local" class="col-sm-2
+                        col-form-label">Alias</label>
+                      <div class="col-sm-10">
+                        <div class="input-group">
+                          <input type="text" id="alias_local" name="alias_local"
+                            class="form-control">
+                          <select class="form-select" id="alias_accepteddomain"
+                            name="alias_accepteddomain">
+                            <!-- {row_ad} -->
+                          </select>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-secondary"
+                        data-bs-dismiss="modal">Cancel</button>
+                      <button type="submit" class="btn btn-primary">Add
+                        Alias</button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+
+        </main>
+      </div>
+    </div>
+    <script>
+feather.replace()
+</script>
+  </body>
+</html>

--- a/web/editremotemailbox.html
+++ b/web/editremotemailbox.html
@@ -208,11 +208,54 @@
             </div>
           </div>
 
+          <div class="card mb-4 border-danger">
+            <div class="card-header bg-danger text-white">Danger Zone</div>
+            <div class="card-body">
+              <p>Disabling this Remote Mailbox removes its Exchange attributes
+                from Active Directory. It will no longer sync as a Remote
+                Mailbox. The Exchange Online mailbox itself is not deleted by
+                this action.</p>
+              <form method="get" action="/editremotemailbox" id="disableForm">
+                <input type="hidden" name="id" value="{id}">
+                <input type="hidden" name="action" value="disable">
+                <div class="mb-3">
+                  <label for="confirmAddress" class="form-label">Type
+                    <strong>{primarysmtpaddress}</strong> to confirm</label>
+                  <input type="text" class="form-control" id="confirmAddress"
+                    name="confirmAddress" autocomplete="off">
+                </div>
+                <button type="submit" class="btn btn-danger" id="disableButton"
+                  disabled>Disable Remote Mailbox</button>
+              </form>
+            </div>
+          </div>
+
         </main>
       </div>
     </div>
     <script>
-feather.replace()
+try { feather.replace(); } catch (e) { console.warn('feather.replace() failed:', e); }
+
+(function () {
+  var expected = "{primarysmtpaddress}".trim().toLowerCase();
+  var input = document.getElementById('confirmAddress');
+  var button = document.getElementById('disableButton');
+  var form = document.getElementById('disableForm');
+
+  function matches() {
+    return input.value.trim().toLowerCase() === expected;
+  }
+
+  input.addEventListener('input', function () {
+    button.disabled = !matches();
+  });
+
+  form.addEventListener('submit', function (e) {
+    if (!matches() || !confirm('This will disable the Remote Mailbox for ' + expected + '. Continue?')) {
+      e.preventDefault();
+    }
+  });
+})();
 </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
The Remote Mailboxes list already links each row to `/editremotemailbox?id=...`, but that route and page didn't exist, so clicking a mailbox 404'd. This PR fills that gap and adds the ability to manage the attributes that aren't exposed anywhere else in the tool:

- View a Remote Mailbox's `Name`, `PrimarySmtpAddress`, and `RemoteRoutingAddress`
- Add or remove proxy addresses (`EmailAddresses` aliases)
- Toggle `HiddenFromAddressListsEnabled` (hide/unhide from the GAL)
- Change `RemoteRoutingAddress`
- Disable a Remote Mailbox (`Disable-RemoteMailbox`), behind a type-to-confirm control that requires typing the mailbox's `PrimarySmtpAddress` before the button enables, checked server-side too so it can't be bypassed client-side

It follows the app's existing conventions exactly: plain GET forms (no JS/AJAX beyond the type-to-confirm check), server-side HTML placeholder templating, and the on-prem Recipient Management Tools snap-in already loaded by the script — no new dependencies.

A second, unrelated commit fixes a robustness bug found while testing: the whole request loop ran inside a single `try/finally` with no `catch`, so any exception writing a response (e.g. a client closing the connection mid-response) crashed the entire webserver for all users. Each request is now handled in its own `try/catch`.

A third commit adds the disable-mailbox capability above, and wraps the page's `feather.replace()` call in try/catch as cheap insurance against icon-library issues blocking the confirm-button script (not an active bug here since this branch vendors feather-icons locally rather than loading it from an unpinned CDN, but harmless and consistent with the same defensive fix I made on a similar page targeting `dev`).

## Test plan
- [x] `Parser]::ParseFile` clean (no PowerShell syntax errors)
- [x] Manually verified against a live on-prem Exchange Management Tools install (view properties, add/remove aliases, toggle HiddenFromAddressListsEnabled, change RemoteRoutingAddress) — confirmed working
- [x] Confirmed the pre-existing dangling `/editremotemailbox?id=...` link now resolves instead of 404ing
- [ ] Disable-mailbox flow (type-to-confirm + `Disable-RemoteMailbox`) has been verified on an equivalent page on my `dev`-targeted branch, but not yet re-tested on this specific branch after porting — I'll confirm and check this box once done
