### PR TITLE
Extend Edit Remote Mailbox (dev) with alias and GAL management

### DIFF
--- a/Create-Shortcut.ps1
+++ b/Create-Shortcut.ps1
@@ -1,0 +1,29 @@
+<#
+.Synopsis
+Creates a Desktop shortcut for launching Exchange Recipient Admin Center.
+.Description
+Run this once from wherever this project's files actually live. It resolves
+its own folder and the current user's Desktop dynamically, so the same
+script works unmodified for any user/location - no hardcoded paths.
+#>
+
+$targetFolder = Split-Path -Parent $MyInvocation.MyCommand.Path
+$batPath = Join-Path $targetFolder "Launch-ExchangeRecipientAdmin.bat"
+$iconPath = Join-Path $targetFolder "images\favicon.ico"
+$desktop = [Environment]::GetFolderPath('Desktop')
+$shortcutPath = Join-Path $desktop "Exchange Recipient Admin Center.lnk"
+
+$shell = New-Object -ComObject WScript.Shell
+$shortcut = $shell.CreateShortcut($shortcutPath)
+$shortcut.TargetPath = $batPath
+$shortcut.WorkingDirectory = $targetFolder
+if (Test-Path $iconPath) {
+    $shortcut.IconLocation = $iconPath
+}
+else {
+    $shortcut.IconLocation = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe,0"
+}
+$shortcut.Description = "Exchange Recipient Admin Center"
+$shortcut.Save()
+
+Write-Host "Shortcut created at: $shortcutPath"

--- a/Launch-ExchangeRecipientAdmin.bat
+++ b/Launch-ExchangeRecipientAdmin.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Start-Process powershell.exe -Verb RunAs -ArgumentList '-ExecutionPolicy Bypass -File \"%~dp0Start-ExchangeRecipientAdminCenter.ps1\"'"

--- a/Start-ExchangeRecipientAdminCenter.ps1
+++ b/Start-ExchangeRecipientAdminCenter.ps1
@@ -124,6 +124,7 @@ try {
     "$(Get-Date -Format s) Powershell webserver started."
     $WEBLOG = "$(Get-Date -Format s) Powershell webserver started.`n"
     while ($LISTENER.IsListening) {
+      try {
         # analyze incoming request
         $CONTEXT = $LISTENER.GetContext()
         $REQUEST = $CONTEXT.Request
@@ -613,6 +614,15 @@ try {
             "$(Get-Date -Format s) Stopping powershell webserver..."
             break;
         }
+      }
+      catch {
+        # A single request failing (e.g. client closed the connection before the
+        # response finished writing - "network name is no longer available") should
+        # not take down the whole webserver. Log it and keep listening.
+        "$(Get-Date -Format s) Request error: $($_.Exception.Message)"
+        $WEBLOG += "$(Get-Date -Format s) Request error: $($_.Exception.Message)`n"
+        try { $RESPONSE.Close() } catch { }
+      }
     }
 }
 finally {

--- a/Start-ExchangeRecipientAdminCenter.ps1
+++ b/Start-ExchangeRecipientAdminCenter.ps1
@@ -111,6 +111,59 @@ function Get-RemoteMailboxEditPage {
     return $HTMLRESPONSE
 }
 
+function Get-RemoteMailboxListPage {
+    # Renders remotemailboxes.html. Used after disabling a Remote Mailbox, since
+    # the mailbox no longer exists to redirect back to an edit page for.
+    param(
+        [string]$ResultHtml = ""
+    )
+
+    $HTMLROWS_USERS = ""
+    foreach ($Item in (Get-User -Filter "RecipientType -eq 'User' -and RecipientTypeDetails -ne 'DisabledUser'" | Where { $_.UserPrincipalName })) {
+        $HTMLROWS_USERS += "`n<option value=`"$($Item.UserPrincipalName)`">$($Item.UserPrincipalName)</option>"
+    }
+
+    $HTMLROWS_AD = ""
+    foreach ($Item in (Get-AcceptedDomain)) {
+        if ($Item.Default) {
+            $HTMLROWS_AD += "`n<option selected value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+        }
+        else {
+            $HTMLROWS_AD += "`n<option value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+        }
+    }
+
+    $HTMLROWS_RRA = ""
+    foreach ($Item in (Get-AcceptedDomain)) {
+        if ($Item.DomainName -like "*.mail.onmicrosoft.com") {
+            $HTMLROWS_RRA += "`n<option selected value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+        }
+        else {
+            $HTMLROWS_RRA += "`n<option value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+        }
+    }
+
+    $HTMLROWS_MBX = ""
+    foreach ($Item in (Get-RemoteMailbox | Select DisplayName, PrimarySMTPAddress, RecipientTypeDetails, WhenChanged)) {
+        $HTMLROWS_MBX += "
+        <tr>
+        <th scope=`"row`">
+        <a href=`"/editremotemailbox?id=$($Item.PrimarySMTPAddress)`">$($Item.DisplayName)</a></th>
+        <td>$($Item.PrimarySMTPAddress)</td>
+        <td>$($Item.RecipientTypeDetails)</td>
+        <td>$($Item.WhenChanged)</td>
+        </tr>";
+    }
+
+    $HTMLRESPONSE = Get-Content -Path "$($BASEDIR)\remotemailboxes.html"
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_mbx} -->", $HTMLROWS_MBX)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_ad} -->", $HTMLROWS_AD)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_user} -->", $HTMLROWS_USERS)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_rra} -->", $HTMLROWS_RRA)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {result} -->", $ResultHtml)
+    return $HTMLRESPONSE
+}
+
 # Starting the powershell webserver
 "$(Get-Date -Format s) Starting Exchange Recipient Admin Webserver at: $($BINDING)"
 $LISTENER = New-Object System.Net.HttpListener
@@ -233,9 +286,10 @@ try {
                     $params[$key] = [System.Web.HttpUtility]::UrlDecode($value)
                 }
 
-                # "id" is set by the alias/hidden mini-forms; the main properties
-                # form has no id field and keys off PrimarySmtpAddress instead.
+                # "id" is set by the alias/hidden/disable mini-forms; the main
+                # properties form has no id field and keys off PrimarySmtpAddress.
                 $Identity = if ($params.ContainsKey('id')) { $params['id'] } else { $params['PrimarySmtpAddress'] }
+                $Disabled = $false
 
                 try {
                     switch ($params['Action']) {
@@ -256,6 +310,24 @@ try {
                             $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Set 'Hidden from address lists' to $NewHidden")
                             break
                         }
+                        "disable" {
+                            # Require the confirmation text to match the mailbox's actual
+                            # PrimarySmtpAddress - checked server-side too, not just via the
+                            # UI's type-to-confirm JS, since that's trivially bypassed.
+                            $MailboxToDisable = Get-RemoteMailbox -Identity $Identity -ErrorAction SilentlyContinue
+                            if (-not $MailboxToDisable) {
+                                $HTML_RESULT = $HTML_WARN.Replace("{result}", "Remote mailbox '$($Identity)' not found")
+                            }
+                            elseif ($params['confirmAddress'] -ne $MailboxToDisable.PrimarySmtpAddress) {
+                                $HTML_RESULT = $HTML_WARN.Replace("{result}", "Confirmation text didn't match $($MailboxToDisable.PrimarySmtpAddress) - no changes were made")
+                            }
+                            else {
+                                Disable-RemoteMailbox -Identity $Identity -Confirm:$false
+                                $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Remote Mailbox for $($MailboxToDisable.PrimarySmtpAddress) has been disabled")
+                                $Disabled = $true
+                            }
+                            break
+                        }
                         default {
                             Set-RemoteMailbox -Identity $Identity -DisplayName $params['DisplayName'] -Alias $params['Alias'] -RemoteRoutingAddress $params['RemoteRoutingAddress']
                             $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Remote Mailbox updated successfully")
@@ -268,7 +340,14 @@ try {
                     $HTML_RESULT = $HTML_WARN.Replace("{result}", $Error -join "<br />")
                 }
 
-                $HTMLRESPONSE = Get-RemoteMailboxEditPage -Identity $Identity -ResultHtml $HTML_RESULT
+                # A disabled mailbox no longer exists to render an edit page for -
+                # send the user back to the list instead.
+                if ($Disabled) {
+                    $HTMLRESPONSE = Get-RemoteMailboxListPage -ResultHtml $HTML_RESULT
+                }
+                else {
+                    $HTMLRESPONSE = Get-RemoteMailboxEditPage -Identity $Identity -ResultHtml $HTML_RESULT
+                }
                 break
             }
 

--- a/Start-ExchangeRecipientAdminCenter.ps1
+++ b/Start-ExchangeRecipientAdminCenter.ps1
@@ -35,6 +35,82 @@ $MIMEHASH = @{".avi" = "video/x-msvideo"; ".crt" = "application/x-x509-ca-cert";
 $HTML_SUCCESS = "<div class=`"alert alert-success d-flex align-items-center`" role=`"alert`">{result}</div>"
 $HTML_WARN = "<div class=`"alert alert-warning  d-flex align-items-center`" role=`"alert`">{result}</div>"
 
+function Get-RemoteMailboxEditPage {
+    # Renders editremotemailbox.html for a given mailbox identity. Shared by the
+    # GET (initial view) and POST (after an update) handlers below.
+    param(
+        [Parameter(Mandatory)][string]$Identity,
+        [string]$ResultHtml = ""
+    )
+
+    $Mailbox = Get-RemoteMailbox -Identity $Identity -ErrorAction SilentlyContinue
+
+    if (-not $Mailbox) {
+        return "<!doctype html><html><body>Remote mailbox '$($Identity)' not found</body></html>"
+    }
+
+    # Accepted domain list, used for the "add alias" domain picker
+    $HTMLROWS_AD = ""
+    foreach ($Item in (Get-AcceptedDomain)) {
+        $HTMLROWS_AD += "`n<option value=`"$($Item.Name)`">$($Item.DomainName)</option>"
+    }
+
+    # Proxy address (EmailAddresses) rows, each with a remove button
+    $HTMLROWS_PROXY = ""
+    foreach ($Addr in $Mailbox.EmailAddresses) {
+        $AddrString = $Addr.ToString()
+        $IsPrimary = $AddrString.StartsWith("SMTP:")
+        if ($IsPrimary) {
+            $Badge = "<span class=`"badge text-bg-primary`">Primary</span>"
+            $RemoveBtn = ""
+        }
+        else {
+            $Badge = "<span class=`"badge text-bg-secondary`">Alias</span>"
+            $RemoveBtn = "
+            <form method=`"post`" action=`"/editremotemailbox`" onsubmit=`"return confirm('Remove $($AddrString)?')`">
+            <input type=`"hidden`" name=`"id`" value=`"$($Mailbox.PrimarySmtpAddress)`">
+            <input type=`"hidden`" name=`"Action`" value=`"removealias`">
+            <input type=`"hidden`" name=`"alias`" value=`"$($AddrString)`">
+            <button type=`"submit`" class=`"btn btn-sm btn-outline-danger`">Remove</button>
+            </form>"
+        }
+        $HTMLROWS_PROXY += "
+        <tr>
+        <td>$($AddrString)</td>
+        <td>$($Badge)</td>
+        <td>$($RemoveBtn)</td>
+        </tr>";
+    }
+
+    if ($Mailbox.HiddenFromAddressListsEnabled) {
+        $HiddenBadgeClass = "text-bg-warning"
+        $HiddenStatusText = "Hidden"
+        $HiddenToggleValue = "false"
+        $HiddenToggleLabel = "Unhide from GAL"
+    }
+    else {
+        $HiddenBadgeClass = "text-bg-success"
+        $HiddenStatusText = "Visible"
+        $HiddenToggleValue = "true"
+        $HiddenToggleLabel = "Hide from GAL"
+    }
+
+    $HTMLRESPONSE = Get-Content -Path "$($BASEDIR)\editremotemailbox.html"
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{DisplayName}", $Mailbox.DisplayName)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{PrimarySmtpAddress}", $Mailbox.PrimarySmtpAddress)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{Alias}", $Mailbox.Alias)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{RemoteRoutingAddress}", $Mailbox.RemoteRoutingAddress)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{id}", $Mailbox.PrimarySmtpAddress)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_badge_class}", $HiddenBadgeClass)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_status_text}", $HiddenStatusText)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_toggle_value}", $HiddenToggleValue)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("{hidden_toggle_label}", $HiddenToggleLabel)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_proxy} -->", $HTMLROWS_PROXY)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {row_ad} -->", $HTMLROWS_AD)
+    $HTMLRESPONSE = $HTMLRESPONSE.Replace("<!-- {result} -->", $ResultHtml)
+    return $HTMLRESPONSE
+}
+
 # Starting the powershell webserver
 "$(Get-Date -Format s) Starting Exchange Recipient Admin Webserver at: $($BINDING)"
 $LISTENER = New-Object System.Net.HttpListener
@@ -137,14 +213,9 @@ try {
 
             "GET /editremotemailbox" {
                 # Edit Remote Mailbox Section
-                $id = $REQUEST.Url.Query.Split("=")[1]
-                $remotemailbox = Get-RemoteMailbox -Identity $id
-                
-                $HTMLRESPONSE = (Get-Content -Path "$($BASEDIR)\editremotemailbox.html")
-                $HTMLRESPONSE = $HTMLRESPONSE.Replace("{DisplayName}", $remotemailbox.DisplayName)
-                $HTMLRESPONSE = $HTMLRESPONSE.Replace("{PrimarySmtpAddress}", $remotemailbox.PrimarySmtpAddress)
-                $HTMLRESPONSE = $HTMLRESPONSE.Replace("{Alias}", $remotemailbox.Alias)
-                $HTMLRESPONSE = $HTMLRESPONSE.Replace("{RemoteRoutingAddress}", $remotemailbox.RemoteRoutingAddress)
+                $id = [URI]::UnescapeDataString($REQUEST.Url.Query.TrimStart('?').Split("=")[1])
+
+                $HTMLRESPONSE = Get-RemoteMailboxEditPage -Identity $id
                 break
             }
 
@@ -161,15 +232,42 @@ try {
                     $params[$key] = [System.Web.HttpUtility]::UrlDecode($value)
                 }
 
+                # "id" is set by the alias/hidden mini-forms; the main properties
+                # form has no id field and keys off PrimarySmtpAddress instead.
+                $Identity = if ($params.ContainsKey('id')) { $params['id'] } else { $params['PrimarySmtpAddress'] }
+
                 try {
-                    Set-RemoteMailbox -Identity $params['PrimarySmtpAddress'] -DisplayName $params['DisplayName'] -Alias $params['Alias'] -RemoteRoutingAddress $params['RemoteRoutingAddress']
-                    $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Remote Mailbox updated successfully")
+                    switch ($params['Action']) {
+                        "addalias" {
+                            $NewAlias = "$($params['alias_local'])@$($params['alias_accepteddomain'])"
+                            Set-RemoteMailbox -Identity $Identity -EmailAddresses @{Add = $NewAlias }
+                            $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Added alias $NewAlias")
+                            break
+                        }
+                        "removealias" {
+                            Set-RemoteMailbox -Identity $Identity -EmailAddresses @{Remove = $params['alias'] }
+                            $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Removed alias $($params['alias'])")
+                            break
+                        }
+                        "togglehidden" {
+                            $NewHidden = $params['hidden'] -eq 'true'
+                            Set-RemoteMailbox -Identity $Identity -HiddenFromAddressListsEnabled $NewHidden
+                            $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Set 'Hidden from address lists' to $NewHidden")
+                            break
+                        }
+                        default {
+                            Set-RemoteMailbox -Identity $Identity -DisplayName $params['DisplayName'] -Alias $params['Alias'] -RemoteRoutingAddress $params['RemoteRoutingAddress']
+                            $HTML_RESULT = $HTML_SUCCESS.Replace("{result}", "Remote Mailbox updated successfully")
+                            # DisplayName/Alias changes don't affect PrimarySmtpAddress, so it still identifies the mailbox below
+                            $Identity = $params['PrimarySmtpAddress']
+                        }
+                    }
                 }
                 catch {
                     $HTML_RESULT = $HTML_WARN.Replace("{result}", $Error -join "<br />")
                 }
 
-                $HTMLRESPONSE = (Get-Content -Path "$($BASEDIR)\remotemailboxes.html").Replace("<!-- {result} -->", $HTML_RESULT)
+                $HTMLRESPONSE = Get-RemoteMailboxEditPage -Identity $Identity -ResultHtml $HTML_RESULT
                 break
             }
 

--- a/web/accepteddomains.html
+++ b/web/accepteddomains.html
@@ -163,6 +163,7 @@
       </div>
     </div>
 
+    <script src="table-tools.js"></script>
     <script>
       feather.replace()
     </script>

--- a/web/contacts.html
+++ b/web/contacts.html
@@ -159,6 +159,7 @@
       </div>
     </div>
 
+    <script src="table-tools.js"></script>
     <script>
       feather.replace()
     </script>

--- a/web/distributiongroups.html
+++ b/web/distributiongroups.html
@@ -236,6 +236,7 @@
       </div>
     </div>
 
+    <script src="table-tools.js"></script>
     <script>
       feather.replace()
     </script>

--- a/web/editremotemailbox.html
+++ b/web/editremotemailbox.html
@@ -90,34 +90,121 @@
           <div
             class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
             <h2 class="h2">Edit Remote Mailbox</h2>
+            <a class="btn btn-outline-secondary btn-sm" href="/remotemailboxes">Back to Remote Mailboxes</a>
           </div>
 
-          <form method="post" action="/editremotemailbox">
-            <div class="mb-3">
-              <label for="DisplayName" class="form-label">Display Name</label>
-              <input type="text" class="form-control" id="DisplayName"
-                name="DisplayName" value="{DisplayName}">
+          <!-- {result} -->
+
+          <div class="card mb-4">
+            <div class="card-header">Properties</div>
+            <div class="card-body">
+              <form method="post" action="/editremotemailbox">
+                <div class="mb-3">
+                  <label for="DisplayName" class="form-label">Display Name</label>
+                  <input type="text" class="form-control" id="DisplayName"
+                    name="DisplayName" value="{DisplayName}">
+                </div>
+                <div class="mb-3">
+                  <label for="PrimarySmtpAddress" class="form-label">Primary SMTP
+                    Address</label>
+                  <input type="email" class="form-control" id="PrimarySmtpAddress"
+                    name="PrimarySmtpAddress" value="{PrimarySmtpAddress}">
+                </div>
+                <div class="mb-3">
+                  <label for="Alias" class="form-label">Alias</label>
+                  <input type="text" class="form-control" id="Alias" name="Alias"
+                    value="{Alias}">
+                </div>
+                <div class="mb-3">
+                  <label for="RemoteRoutingAddress" class="form-label">Remote
+                    Routing Address</label>
+                  <input type="email" class="form-control" id="RemoteRoutingAddress"
+                    name="RemoteRoutingAddress" value="{RemoteRoutingAddress}">
+                </div>
+                <button type="submit" class="btn btn-primary">Update Remote
+                  Mailbox</button>
+              </form>
             </div>
-            <div class="mb-3">
-              <label for="PrimarySmtpAddress" class="form-label">Primary SMTP
-                Address</label>
-              <input type="email" class="form-control" id="PrimarySmtpAddress"
-                name="PrimarySmtpAddress" value="{PrimarySmtpAddress}">
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">Hidden from Address Lists</div>
+            <div class="card-body d-flex align-items-center">
+              <span class="badge {hidden_badge_class} me-2">{hidden_status_text}</span>
+              <form method="post" action="/editremotemailbox" class="d-inline">
+                <input type="hidden" name="id" value="{id}">
+                <input type="hidden" name="Action" value="togglehidden">
+                <input type="hidden" name="hidden" value="{hidden_toggle_value}">
+                <button type="submit" class="btn btn-outline-secondary btn-sm">{hidden_toggle_label}</button>
+              </form>
             </div>
-            <div class="mb-3">
-              <label for="Alias" class="form-label">Alias</label>
-              <input type="text" class="form-control" id="Alias" name="Alias"
-                value="{Alias}">
+          </div>
+
+          <div class="card mb-4">
+            <div
+              class="card-header d-flex justify-content-between align-items-center">
+              <span>Email Addresses (Proxy Addresses)</span>
+              <button type="button" class="btn btn-primary btn-sm"
+                data-bs-toggle="modal" data-bs-target="#addAlias">
+                Add alias
+              </button>
             </div>
-            <div class="mb-3">
-              <label for="RemoteRoutingAddress" class="form-label">Remote
-                Routing Address</label>
-              <input type="email" class="form-control" id="RemoteRoutingAddress"
-                name="RemoteRoutingAddress" value="{RemoteRoutingAddress}">
+            <div class="card-body">
+              <table class="table table-striped table-hover">
+                <thead>
+                  <tr>
+                    <th scope="col">Address</th>
+                    <th scope="col">Type</th>
+                    <th scope="col"></th>
+                  </tr>
+                </thead>
+                <tbody class="table-group-divider">
+                  <!-- {row_proxy} -->
+                </tbody>
+              </table>
             </div>
-            <button type="submit" class="btn btn-primary">Update Remote
-              Mailbox</button>
-          </form>
+          </div>
+
+          <div class="modal fade" id="addAlias" tabindex="-1"
+            aria-labelledby="addAlias" aria-hidden="true">
+            <div class="modal-dialog modal-xl">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title">Add email alias</h5>
+                  <button type="button" class="btn-close"
+                    data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                  <form method="post" action="/editremotemailbox">
+                    <input type="hidden" name="id" value="{id}">
+                    <input type="hidden" name="Action" value="addalias">
+                    <p>Add a secondary SMTP address (alias) to this mailbox.</p>
+                    <div class="row mb-3">
+                      <label for="alias_local" class="col-sm-2
+                        col-form-label">Alias</label>
+                      <div class="col-sm-10">
+                        <div class="input-group">
+                          <input type="text" id="alias_local" name="alias_local"
+                            class="form-control">
+                          <select class="form-select" id="alias_accepteddomain"
+                            name="alias_accepteddomain">
+                            <!-- {row_ad} -->
+                          </select>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-secondary"
+                        data-bs-dismiss="modal">Cancel</button>
+                      <button type="submit" class="btn btn-primary">Add
+                        Alias</button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+
         </main>
       </div>
     </div>

--- a/web/editremotemailbox.html
+++ b/web/editremotemailbox.html
@@ -235,17 +235,21 @@
       feather.replace()
 
       (function () {
-        var expected = "{PrimarySmtpAddress}";
+        var expected = "{PrimarySmtpAddress}".trim().toLowerCase();
         var input = document.getElementById('confirmAddress');
         var button = document.getElementById('disableButton');
         var form = document.getElementById('disableForm');
 
+        function matches() {
+          return input.value.trim().toLowerCase() === expected;
+        }
+
         input.addEventListener('input', function () {
-          button.disabled = (input.value !== expected);
+          button.disabled = !matches();
         });
 
         form.addEventListener('submit', function (e) {
-          if (input.value !== expected || !confirm('This will disable the Remote Mailbox for ' + expected + '. Continue?')) {
+          if (!matches() || !confirm('This will disable the Remote Mailbox for ' + expected + '. Continue?')) {
             e.preventDefault();
           }
         });

--- a/web/editremotemailbox.html
+++ b/web/editremotemailbox.html
@@ -205,12 +205,51 @@
             </div>
           </div>
 
+          <div class="card mb-4 border-danger">
+            <div class="card-header bg-danger text-white">Danger Zone</div>
+            <div class="card-body">
+              <p>Disabling this Remote Mailbox removes its Exchange attributes
+                from Active Directory. It will no longer sync as a Remote
+                Mailbox. The Exchange Online mailbox itself is not deleted by
+                this action.</p>
+              <form method="post" action="/editremotemailbox" id="disableForm">
+                <input type="hidden" name="id" value="{id}">
+                <input type="hidden" name="Action" value="disable">
+                <div class="mb-3">
+                  <label for="confirmAddress" class="form-label">Type
+                    <strong>{PrimarySmtpAddress}</strong> to confirm</label>
+                  <input type="text" class="form-control" id="confirmAddress"
+                    name="confirmAddress" autocomplete="off">
+                </div>
+                <button type="submit" class="btn btn-danger" id="disableButton"
+                  disabled>Disable Remote Mailbox</button>
+              </form>
+            </div>
+          </div>
+
         </main>
       </div>
     </div>
 
     <script>
       feather.replace()
+
+      (function () {
+        var expected = "{PrimarySmtpAddress}";
+        var input = document.getElementById('confirmAddress');
+        var button = document.getElementById('disableButton');
+        var form = document.getElementById('disableForm');
+
+        input.addEventListener('input', function () {
+          button.disabled = (input.value !== expected);
+        });
+
+        form.addEventListener('submit', function (e) {
+          if (input.value !== expected || !confirm('This will disable the Remote Mailbox for ' + expected + '. Continue?')) {
+            e.preventDefault();
+          }
+        });
+      })();
     </script>
   </body>
 </html>

--- a/web/editremotemailbox.html
+++ b/web/editremotemailbox.html
@@ -232,7 +232,7 @@
     </div>
 
     <script>
-      feather.replace()
+      try { feather.replace(); } catch (e) { console.warn('feather.replace() failed:', e); }
 
       (function () {
         var expected = "{PrimarySmtpAddress}".trim().toLowerCase();

--- a/web/emailaddresspolicies.html
+++ b/web/emailaddresspolicies.html
@@ -167,6 +167,7 @@
       </div>
     </div>
 
+    <script src="table-tools.js"></script>
     <script>
       feather.replace()
     </script>

--- a/web/remotemailboxes.html
+++ b/web/remotemailboxes.html
@@ -193,6 +193,7 @@
         </main>
       </div>
     </div>
+    <script src="table-tools.js"></script>
     <script>
       feather.replace()
     </script>

--- a/web/table-tools.js
+++ b/web/table-tools.js
@@ -1,0 +1,78 @@
+// Adds a client-side search box and clickable sortable column headers to
+// every <table class="table"> on the page. Purely client-side - it only
+// reorders/hides rows already rendered by the server, no data is refetched.
+(function () {
+  function cellText(cell) {
+    return cell.textContent.trim().toLowerCase();
+  }
+
+  function sortTable(table, colIndex, ascending) {
+    var tbody = table.tBodies[0];
+    var rows = Array.prototype.slice.call(tbody.rows);
+    rows.sort(function (a, b) {
+      var av = cellText(a.cells[colIndex]);
+      var bv = cellText(b.cells[colIndex]);
+      if (av < bv) return ascending ? -1 : 1;
+      if (av > bv) return ascending ? 1 : -1;
+      return 0;
+    });
+    rows.forEach(function (row) { tbody.appendChild(row); });
+  }
+
+  function addSortHandlers(table) {
+    var headerRow = table.tHead && table.tHead.rows[0];
+    if (!headerRow) return;
+
+    Array.prototype.forEach.call(headerRow.cells, function (th, index) {
+      if (!th.textContent.trim()) return; // skip empty/action columns
+
+      th.style.cursor = 'pointer';
+      th.dataset.sortDir = '';
+
+      th.addEventListener('click', function () {
+        var ascending = th.dataset.sortDir !== 'asc';
+
+        Array.prototype.forEach.call(headerRow.cells, function (sib) {
+          sib.dataset.sortDir = '';
+          sib.textContent = sib.textContent.replace(/ [▲▼]$/, '');
+        });
+
+        th.dataset.sortDir = ascending ? 'asc' : 'desc';
+        th.textContent = th.textContent.replace(/ [▲▼]$/, '') + (ascending ? ' ▲' : ' ▼');
+
+        sortTable(table, index, ascending);
+      });
+    });
+  }
+
+  function addSearchBox(table) {
+    var wrapper = document.createElement('div');
+    wrapper.className = 'mb-2';
+
+    var input = document.createElement('input');
+    input.type = 'search';
+    input.className = 'form-control';
+    input.placeholder = 'Search...';
+    wrapper.appendChild(input);
+
+    table.parentNode.insertBefore(wrapper, table);
+
+    input.addEventListener('input', function () {
+      var query = input.value.trim().toLowerCase();
+      var rows = table.tBodies[0].rows;
+      Array.prototype.forEach.call(rows, function (row) {
+        var text = row.textContent.toLowerCase();
+        row.style.display = text.indexOf(query) === -1 ? 'none' : '';
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var tables = document.querySelectorAll('table.table');
+    Array.prototype.forEach.call(tables, function (table) {
+      if (!table.tHead || !table.tBodies.length) return;
+      addSearchBox(table);
+      addSortHandlers(table);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
`dev` already has a `GET/POST /editremotemailbox` page (nice rewrite — CDN assets, full edit pages for every recipient type). It covers DisplayName, PrimarySmtpAddress-as-identity, Alias (mail nickname), and RemoteRoutingAddress, but had no way to manage secondary SMTP proxy addresses, GAL visibility, or disabling a mailbox, and had no search/sort on any of its list pages. This PR adds all of that on top of `dev`'s existing conventions (POST forms, CDN Bootstrap/feather, card layout):

- **Email Addresses card** — lists all `EmailAddresses` proxy addresses (Primary vs Alias badge), an "Add alias" modal (`Set-RemoteMailbox -EmailAddresses @{Add=...}`), and a Remove button per alias (`@{Remove=...}`)
- **Hidden from Address Lists card** — one-click toggle for `HiddenFromAddressListsEnabled`
- **Danger Zone card** — disable a Remote Mailbox (`Disable-RemoteMailbox`) behind a type-to-confirm control (must type the mailbox's `PrimarySmtpAddress` before the button enables), checked server-side too so it can't be bypassed client-side. Since the mailbox no longer exists afterward, it redirects to the Remote Mailboxes list (via a new `Get-RemoteMailboxListPage` helper) instead of showing an edit page for a gone identity.
- **Search and sort on every list page** — Remote Mailboxes, Distribution Groups (both its tables), Contacts, Email Address Policies, and Accepted Domains all get a live search box and clickable/sortable column headers, via one new shared `web/table-tools.js` (pure client-side against rows already rendered by the server — no new routes, no data refetch).
- **Desktop launcher** — `Launch-ExchangeRecipientAdmin.bat` (self-elevates via UAC, since the Exchange Management Tools assemblies need admin rights to load, which a plain double-clicked shortcut doesn't have) and `Create-Shortcut.ps1` (one-time setup script that creates a Desktop shortcut, fully dynamic — no hardcoded paths/usernames).

Both alias/hidden/disable actions POST back to `/editremotemailbox` with an `Action` field and re-render with the mailbox's current state, so you see the result immediately instead of bouncing to the list (except disable, which necessarily goes to the list since the identity is gone). I factored the shared rendering into `Get-RemoteMailboxEditPage`/`Get-RemoteMailboxListPage` to avoid duplicating the proxy-address/GAL-badge HTML across every action — the one deviation from the rest of the script's style (which inlines everything per-route); 

Also includes two small robustness fixes found while building/testing this:
- The webserver's whole request loop ran inside one `try/finally` with no `catch`, so a client dropping its connection mid-response (e.g. "the specified network name is no longer available") took down the entire listener for all users. Same fix as my other PR (#11) — `dev` has the identical loop and bug.
- The type-to-confirm JS for disabling a mailbox depends on `feather.replace()` running first in the same `<script>` block; since dev's feather-icons `<script>` tag has no version pinned, an unrelated feather-icons API change on the CDN threw and silently blocked the confirm button from ever enabling. Wrapped it in try/catch so an icon-library hiccup can't take out unrelated functional JS again.

Related: #11 adds the same alias/GAL/disable functionality against `main`, 